### PR TITLE
Fixes #12 finding submodules for sphinx docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,19 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.12'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        pip install . sphinx myst_parser
+        pip install sphinx 
+        pip install myst_parser
+        pip install .
+    - name: List src directory for debugging
+      run: |
+         ls -R src
+    - name: Verify installation
+      run: |
+        pip show SimLogger
     - name: Build HTML
       run: |
         cd docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../src"))
-sys.path.insert(0, os.path.abspath("../../src/SimLogger"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information


### PR DESCRIPTION
Due to an extra path added in conf.py sphinx didn't check the folder structure correctly.

Additionally some modifications to the docs workflow were added for potential debugging later