### PR TITLE
Fixed Notify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "SimLogger"
 description = "Simplify scientific data logging"
-version = "0.4.1"
+version = "0.4.2"
 readme = "README.md"
 authors = [{ name = "Joey Kilgore", email = "joey.a.kilgore@gmail.com"}]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
 [project]
 name = "SimLogger"
 description = "Simplify scientific data logging"
-version = "0.3.1"
+version = "0.4.1"
 readme = "README.md"
 authors = [{ name = "Joey Kilgore", email = "joey.a.kilgore@gmail.com"}]
 dependencies = [
     "pandas",
     "plotly",
     "figurl",
-    "GitPython",
-    "notify_run"
+    "GitPython"
 ]
 
 [project.url]

--- a/src/SimLogger/SimNotify.py
+++ b/src/SimLogger/SimNotify.py
@@ -1,26 +1,18 @@
-from notify_run import Notify
 from SimLogger import SimLogger
+import requests
 
-
-def sendNotification(text, endpoint=None):
+def sendNotification(text, endpoint):
     """Send notification using notify! Check the README.md for setup details.
 
     Args:
         text (str): text that will be sent as the notification (typically simTag and
-            message) endpoint (str, optional): If a notify channel (endpoint) has
-            been setup (*which you should*) include the link here, and the
-            notification will be sent to that channel. If you don't include this
-            then a channel will be generated and you can view it after the fact.
+            message) 
+        endpoint (str): The channel the notifications will be sent to
 
     """
-    if endpoint is None:
-        notify = Notify()
-        endpoint = notify.register()
-        SimLogger.logNotes("WARNING: NOTIFY NOT CONFIGURED. PLEASE SEE README.MD")
-    else:
-        # simplify handling if users don't remove /c/
-        endpoint = endpoint.replace("/c/", "/")
-        notify = Notify(endpoint=endpoint)
+
+    endpoint = endpoint.replace("/c/","/").strip("/")
 
     SimLogger.logNotes(f"USING NOTIFY ENDPOINT: {endpoint}")
-    notify.send(text)
+    response = requests.post(endpoint, data=text, headers={})
+    SimLogger.logNotes(f"NOTIFICATION SENT:{str(response)} {text}")

--- a/src/SimLogger/SimNotify.py
+++ b/src/SimLogger/SimNotify.py
@@ -17,3 +17,5 @@ def sendNotification(text, endpoint):
     SimLogger.logNotes(f"USING NOTIFY ENDPOINT: {endpoint}")
     response = requests.post(endpoint, data=text, headers={})
     SimLogger.logNotes(f"NOTIFICATION SENT:{str(response)} {text}")
+
+    return response

--- a/src/SimLogger/SimNotify.py
+++ b/src/SimLogger/SimNotify.py
@@ -1,17 +1,18 @@
 from SimLogger import SimLogger
 import requests
 
+
 def sendNotification(text, endpoint):
     """Send notification using notify! Check the README.md for setup details.
 
     Args:
         text (str): text that will be sent as the notification (typically simTag and
-            message) 
+            message)
         endpoint (str): The channel the notifications will be sent to
 
     """
 
-    endpoint = endpoint.replace("/c/","/").strip("/")
+    endpoint = endpoint.replace("/c/", "/").strip("/")
 
     SimLogger.logNotes(f"USING NOTIFY ENDPOINT: {endpoint}")
     response = requests.post(endpoint, data=text, headers={})

--- a/tests/test_SimNotify.py
+++ b/tests/test_SimNotify.py
@@ -1,0 +1,8 @@
+from SimLogger import SimNotify
+
+
+def test_notification():
+    endpoint = "https://notify.run/c/WfwXBjk3bD3UrJOV9zRc"
+
+    response = SimNotify.sendNotification("TEST NOTIFICATION", endpoint)
+    assert response.ok


### PR DESCRIPTION
Previously, error were occuring with using the notify-run python library instead, I bypass the need for setting up the configuration, and just enforce users to input the channel endpoint and make the request manually

This seems to be much more reliable