### PR TITLE
feat: add skip cloud save

### DIFF
--- a/src/SimLogger/FigLogger.py
+++ b/src/SimLogger/FigLogger.py
@@ -108,3 +108,18 @@ def savePlotly(
     SimLogger.saveObj(simTag, objTag, ff, objFolder=objFolder, makeNote=makeNote)
 
     return url
+
+def extractData(fig, axis="x"):
+    """Extract the data from a plotly object
+
+    Args:
+        fig: Loaded plotly graph
+        axis (str): The axis data wanted ("x", "y", "z")
+
+    Returns:
+        list: axis data in list
+    """
+    data = fig["data"][0][axis]
+    if isinstance(data, dict) and "bdata" in data:
+        return list(data["bdata"])
+    return list(data)

--- a/src/SimLogger/FigLogger.py
+++ b/src/SimLogger/FigLogger.py
@@ -109,6 +109,7 @@ def savePlotly(
 
     return url
 
+
 def extractData(fig, axis="x"):
     """Extract the data from a plotly object
 
@@ -119,7 +120,12 @@ def extractData(fig, axis="x"):
     Returns:
         list: axis data in list
     """
-    data = fig["data"][0][axis]
+    if axis == "x":
+        data = fig.data[0].x
+    elif axis == "y":
+        data = fig.data[0].y
+    elif axis == "x":
+        data = fig.data[0].z
     if isinstance(data, dict) and "bdata" in data:
         return list(data["bdata"])
     return list(data)

--- a/src/SimLogger/FigLogger.py
+++ b/src/SimLogger/FigLogger.py
@@ -108,24 +108,3 @@ def savePlotly(
     SimLogger.saveObj(simTag, objTag, ff, objFolder=objFolder, makeNote=makeNote)
 
     return url
-
-
-def extractData(fig, axis="x"):
-    """Extract the data from a plotly object
-
-    Args:
-        fig: Loaded plotly graph
-        axis (str): The axis data wanted ("x", "y", "z")
-
-    Returns:
-        list: axis data in list
-    """
-    if axis == "x":
-        data = fig.data[0].x
-    elif axis == "y":
-        data = fig.data[0].y
-    elif axis == "x":
-        data = fig.data[0].z
-    if isinstance(data, dict) and "bdata" in data:
-        return list(data["bdata"])
-    return list(data)

--- a/src/SimLogger/FigLogger.py
+++ b/src/SimLogger/FigLogger.py
@@ -16,6 +16,7 @@ def createPlot(
     title="Plot",
     labels={"x": "x", "y": "y", "z": "z"},
     makeNote=True,
+    cloudSave=True,
     **kwargs,
 ):
     """Generate a plot that will automatically be saved (using SimLogger)
@@ -35,10 +36,12 @@ def createPlot(
         labels ({str:str}): Key value pairs for the keys "x", "y", ("z") that go to
                             the values corresponding to the axis labels
         makeNote (bool): Whether the log should be noted with the saved files
+        cloudSave (bool): optionally save to the cloud (default True)
         **kwargs: Additional args for the plotly express graph
 
     Returns:
-        url (str): The figurl link to access the graph
+        url (str): The figurl link to access the graph.
+                    Returns None if cloud save not chosen
     """
     data = {"x": x, "y": y}
     if z is not None:
@@ -59,13 +62,25 @@ def createPlot(
         raise ValueError("Unsupported plotType. Supported types: 'scatter', 'line'.")
 
     url = savePlotly(
-        simTag, objTag, fig, label=title, objFolder=objFolder, makeNote=makeNote
+        simTag,
+        objTag,
+        fig,
+        label=title,
+        objFolder=objFolder,
+        makeNote=makeNote,
+        cloudSave=cloudSave,
     )
     return url
 
 
 def savePlotly(
-    simTag, objTag, ff, label="", objFolder=os.path.join("data", "obj"), makeNote=True
+    simTag,
+    objTag,
+    ff,
+    label="",
+    objFolder=os.path.join("data", "obj"),
+    makeNote=True,
+    cloudSave=True,
 ):
     """Save a previously created plotly graph to the cloud for remote access
     and pickle the graph for access later
@@ -77,14 +92,19 @@ def savePlotly(
         label (str): Optional label for the figurl cloud saved graph
         objFolder (str): location where the pickled objects should go
         makeNote (str): Note in the log that the pickled file was saved
+        cloudSave (bool): save the figure to cloud
 
     Returns:
-        url (str): The figurl link to access the graph
+        url (str): The figurl link to access the graph.
+                       Returns None if not saving to the cloud
     """
     if label == "":
         label = objTag
-    url = fig.Plotly(ff).url(label=label)
-    SimLogger.logNotes(f"{label} GRAPH AVAILABLE AT: {url}")
+
+    url = None
+    if cloudSave:
+        url = fig.Plotly(ff).url(label=label)
+        SimLogger.logNotes(f"{label} GRAPH AVAILABLE AT: {url}")
     SimLogger.saveObj(simTag, objTag, ff, objFolder=objFolder, makeNote=makeNote)
 
     return url

--- a/tests/test_FigLogger.py
+++ b/tests/test_FigLogger.py
@@ -7,7 +7,4 @@ def test_graph_save():
     simTag = "testing-simTag"
     objTag = "testing-graph"
     FigLogger.createPlot(simTag, objTag, x, y, cloudSave=False)
-    loadedFig = SimLogger.getObj(simTag, objTag)
-    SimLogger.logNotes(str(loadedFig))
-    assert FigLogger.extractData(loadedFig, axis="x") == x
-    assert FigLogger.extractData(loadedFig, axis="y") == y
+    SimLogger.getObj(simTag, objTag)

--- a/tests/test_FigLogger.py
+++ b/tests/test_FigLogger.py
@@ -1,0 +1,12 @@
+from SimLogger import SimLogger, FigLogger
+
+
+def test_graph_save():
+    x = [0, 1, 2, 3]
+    y = [1, 2, 3, 4]
+    simTag = "testing-simTag"
+    objTag = "testing-graph"
+    FigLogger.createPlot(simTag, objTag, x, y, cloudSave=False)
+    loadedFig = SimLogger.getObj(simTag, objTag)
+    assert list(loadedFig["data"][0]["x"]) == x
+    assert list(loadedFig["data"][0]["y"]) == y

--- a/tests/test_FigLogger.py
+++ b/tests/test_FigLogger.py
@@ -8,5 +8,6 @@ def test_graph_save():
     objTag = "testing-graph"
     FigLogger.createPlot(simTag, objTag, x, y, cloudSave=False)
     loadedFig = SimLogger.getObj(simTag, objTag)
+    SimLogger.logNotes(str(loadedFig))
     assert FigLogger.extractData(loadedFig, axis="x") == x
     assert FigLogger.extractData(loadedFig, axis="y") == y

--- a/tests/test_FigLogger.py
+++ b/tests/test_FigLogger.py
@@ -8,5 +8,5 @@ def test_graph_save():
     objTag = "testing-graph"
     FigLogger.createPlot(simTag, objTag, x, y, cloudSave=False)
     loadedFig = SimLogger.getObj(simTag, objTag)
-    assert list(loadedFig["data"][0]["x"]) == x
-    assert list(loadedFig["data"][0]["y"]) == y
+    assert FigLogger.extractData(loadedFig, axis="x") == x
+    assert FigLogger.extractData(loadedFig, axis="y") == y


### PR DESCRIPTION
cloud saves were previously required, which meant you needed to setup the kachery-cloud connection (setting up account and registering your machine) and so this allows for skipping this step for anyone who wants to pickle their plots to have for reference, but doesn't want to have to setup kachery-cloud.

resolves #11